### PR TITLE
게시글, 댓글 서비스 로직의 테스트와 골격을 잡고, 루트 경로를 게시판 페이지로 forward 하도록 컨트롤러 구현

### DIFF
--- a/bootBoard/src/main/java/gc/bootboard/controller/MainController.java
+++ b/bootBoard/src/main/java/gc/bootboard/controller/MainController.java
@@ -1,0 +1,12 @@
+package gc.bootboard.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+    @GetMapping("/")
+    public String root() {
+        return "forward:/articles";
+    }
+}

--- a/bootBoard/src/main/java/gc/bootboard/domain/Article.java
+++ b/bootBoard/src/main/java/gc/bootboard/domain/Article.java
@@ -3,14 +3,8 @@ package gc.bootboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/bootBoard/src/main/java/gc/bootboard/domain/ArticleComment.java
+++ b/bootBoard/src/main/java/gc/bootboard/domain/ArticleComment.java
@@ -3,14 +3,8 @@ package gc.bootboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter

--- a/bootBoard/src/main/java/gc/bootboard/domain/type/SearchType.java
+++ b/bootBoard/src/main/java/gc/bootboard/domain/type/SearchType.java
@@ -1,0 +1,5 @@
+package gc.bootboard.domain.type;
+
+public enum SearchType {
+    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+}

--- a/bootBoard/src/main/java/gc/bootboard/dto/ArticleCommentDto.java
+++ b/bootBoard/src/main/java/gc/bootboard/dto/ArticleCommentDto.java
@@ -1,0 +1,19 @@
+package gc.bootboard.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link gc.bootboard.domain.ArticleComment}
+ */
+public record ArticleCommentDto(
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy,
+        String content
+) {
+    public static ArticleCommentDto of(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String content) {
+        return new ArticleCommentDto(createdAt, createdBy, modifiedAt, modifiedBy, content);
+    }
+}

--- a/bootBoard/src/main/java/gc/bootboard/dto/ArticleDto.java
+++ b/bootBoard/src/main/java/gc/bootboard/dto/ArticleDto.java
@@ -1,0 +1,19 @@
+package gc.bootboard.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link gc.bootboard.domain.Article}
+ */
+public record ArticleDto(
+        LocalDateTime createdAt,
+        String createdBy,
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleDto of(LocalDateTime createdAt, String createdBy, String title, String content, String hashtag) {
+        return new ArticleDto(createdAt, createdBy, title, content, hashtag);
+    }
+}

--- a/bootBoard/src/main/java/gc/bootboard/dto/ArticleUpdateDto.java
+++ b/bootBoard/src/main/java/gc/bootboard/dto/ArticleUpdateDto.java
@@ -1,0 +1,16 @@
+package gc.bootboard.dto;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link gc.bootboard.domain.Article}
+ */
+public record ArticleUpdateDto(
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleUpdateDto of(String title, String content, String hashtag) {
+        return new ArticleUpdateDto(title, content, hashtag);
+    }
+}

--- a/bootBoard/src/main/java/gc/bootboard/service/ArticleCommentService.java
+++ b/bootBoard/src/main/java/gc/bootboard/service/ArticleCommentService.java
@@ -1,0 +1,27 @@
+package gc.bootboard.service;
+
+import gc.bootboard.dto.ArticleCommentDto;
+import gc.bootboard.repository.ArticleCommentRepository;
+import gc.bootboard.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleCommentService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleCommentRepository articleCommentRepository;
+
+    @Transactional(readOnly = true)
+    public List<ArticleCommentDto> searchArticleComment(Long articleId) {
+        return List.of();
+    }
+
+    public void saveArticleComment(ArticleCommentDto dto) {
+    }
+}

--- a/bootBoard/src/main/java/gc/bootboard/service/ArticleService.java
+++ b/bootBoard/src/main/java/gc/bootboard/service/ArticleService.java
@@ -1,0 +1,39 @@
+package gc.bootboard.service;
+
+import gc.bootboard.domain.type.SearchType;
+import gc.bootboard.dto.ArticleDto;
+import gc.bootboard.dto.ArticleUpdateDto;
+import gc.bootboard.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public List<ArticleDto> searchArticles(SearchType searchType, String searchKeyword) {
+        return List.of();
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleDto searchArticles(long l) {
+        return null;
+    }
+
+    public void saveArticle(ArticleDto dto) {
+    }
+
+    public void updateArticle(long articleId, ArticleUpdateDto dto) {
+
+    }
+
+    public void deleteArticle(Long articleId) {
+    }
+}

--- a/bootBoard/src/main/resources/templates/index.html
+++ b/bootBoard/src/main/resources/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
+    <title>Welcome page</title>
+</head>
+<body>
+Welcome!
+<!-- TODO: 루트 경로는 게시판으로 redirect 되므로, 이 페이지는 이제 쓰이지 않는다. 나중에 삭제 검토. -->
+</body>
+</html>

--- a/bootBoard/src/test/java/gc/bootboard/controller/MainControllerTest.java
+++ b/bootBoard/src/test/java/gc/bootboard/controller/MainControllerTest.java
@@ -1,0 +1,34 @@
+package gc.bootboard.controller;
+
+import gc.bootboard.config.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+    private final MockMvc mvc;
+
+    public MainControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Test
+    void givenNothing_whenRequestingRootPage_thenRedirectsToArticlesPage() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/articles"))
+                .andExpect(forwardedUrl("/articles"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+}

--- a/bootBoard/src/test/java/gc/bootboard/repository/JpaArticleRepositoryTest.java
+++ b/bootBoard/src/test/java/gc/bootboard/repository/JpaArticleRepositoryTest.java
@@ -6,14 +6,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.Rollback;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("JPA 연결 테스트")
 @Import(JpaConfig.class)

--- a/bootBoard/src/test/java/gc/bootboard/service/ArticleCommentServiceTest.java
+++ b/bootBoard/src/test/java/gc/bootboard/service/ArticleCommentServiceTest.java
@@ -1,0 +1,62 @@
+package gc.bootboard.service;
+
+import gc.bootboard.domain.Article;
+import gc.bootboard.domain.ArticleComment;
+import gc.bootboard.dto.ArticleCommentDto;
+import gc.bootboard.repository.ArticleCommentRepository;
+import gc.bootboard.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 댓글")
+@ExtendWith(MockitoExtension.class)
+class ArticleCommentServiceTest {
+
+    @InjectMocks private ArticleCommentService sut;
+
+    @Mock private ArticleRepository articleRepository;
+    @Mock private ArticleCommentRepository articleCommentRepository;
+
+    @DisplayName("게시글 ID로 조회하면, 해당하는 댓글 리스트를 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticleComments_thenReturnsArticleComments() {
+        // Given
+        Long articleId = 1L;
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(
+                Article.of("title", "content", "#java"))
+        );
+
+        // When
+        List<ArticleCommentDto> articleComments = sut.searchArticleComment(articleId);
+
+        // Then
+        assertThat(articleComments).isNotNull();
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")
+    @Test
+    void givenArticleCommentInfo_whenSavingArticleComment_thenSavesArticleComment() {
+        // Given
+        given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(null);
+
+        // When
+        sut.saveArticleComment(ArticleCommentDto.of(LocalDateTime.now(), "Uno", LocalDateTime.now(), "lim", "comment"));
+
+        // Then
+        then(articleCommentRepository).should().save(any(ArticleComment.class));
+    }
+}

--- a/bootBoard/src/test/java/gc/bootboard/service/ArticleServiceTest.java
+++ b/bootBoard/src/test/java/gc/bootboard/service/ArticleServiceTest.java
@@ -1,0 +1,94 @@
+package gc.bootboard.service;
+
+import gc.bootboard.domain.Article;
+import gc.bootboard.domain.type.SearchType;
+import gc.bootboard.dto.ArticleDto;
+import gc.bootboard.dto.ArticleUpdateDto;
+import gc.bootboard.repository.ArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+
+@DisplayName("비즈니스 로직 - 게시글")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+    @InjectMocks
+    private ArticleService sut; //  sut: system under test
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @DisplayName("게시글 검색하면, 게시글 리스트를 반환한다.")
+    @Test
+    void givenSearchParameters_whenSearchingArticles_thenArticleList() {
+        // Given
+
+        // When
+        List<ArticleDto> articles = sut.searchArticles(SearchType.TITLE, "search keyword"); // 제목, 본문, ID, 닉네임, 해시태그
+
+        // Then
+        assertThat(articles).isNotNull();
+    }
+
+    @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticle_thenReturnsArticle() {
+        // Given
+
+
+        // When
+        ArticleDto articles = sut.searchArticles(1L); // 제목, 본문, ID, 닉네임, 해시태그
+
+        // Then
+        assertThat(articles).isNotNull();
+    }
+
+    @DisplayName("게시글을 정보를 입력하면, 게시글을 생성한다.")
+    @Test
+    void givenArticleInfo_whenSavingArticle_thenSavesArticle() {
+        // Given - BDDMockito 첫 사용!
+        given(articleRepository.save(any(Article.class))).willReturn(null);
+
+        // When
+        sut.saveArticle(ArticleDto.of(LocalDateTime.now(), "Lim", "title", "content", "#java"));
+
+        // Then - save 를 한 번 호출했는지 확인
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 ID와 수정 정보를 입력하면, 게시글을 수정한다.")
+    @Test
+    void givenArticleIdAndModifiedInfo_whenUpdatingArticle_thenUpdatesArticle() {
+        // Given - BDDMockito 첫 사용!
+        given(articleRepository.save(any(Article.class))).willReturn(null);
+
+        // When
+        sut.updateArticle(1L, ArticleUpdateDto.of("title", "content", "#java"));
+
+        // Then - save 를 한 번 호출했는지 확인
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다.")
+    @Test
+    void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
+        // Given - BDDMockito 첫 사용!
+        willDoNothing().given(articleRepository).delete(any(Article.class));
+
+        // When
+        sut.deleteArticle(1L);
+        // Then - save 를 한 번 호출했는지 확인
+        then(articleRepository).should().delete(any(Article.class));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 서비스 로직의 테스트와 골격을 잡고, 루트 경로를 게시판 페이지로 forward 하도록 컨트롤러 구현합니다.

이전에 풀 리퀘스트한 #20 과 함께 작업해야 하는데 꼬여서 빠르게 커밋부터 합니다.